### PR TITLE
fix: installation instructions pom version

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -42,7 +42,7 @@ After building from source, add JMiniApp as a dependency in your project's `pom.
 <dependency>
     <groupId>com.jminiapp</groupId>
     <artifactId>jminiapp-core</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Update on the dependency instructions for the pom.xml of the app project (At least for the IntelliJ IDE)

New Version:

<dependency>
     <groupId>com.jminiapp</groupId>
     <artifactId>jminiapp-core</artifactId>
     <version>1.0.0-SNAPSHOT</version>
</dependency>