### PR TITLE
fix: add defensive mutable copy to set data

### DIFF
--- a/modules/core/src/main/java/com/jminiapp/core/engine/AppState.java
+++ b/modules/core/src/main/java/com/jminiapp/core/engine/AppState.java
@@ -68,11 +68,17 @@ public class AppState {
     /**
      * Set the data for this state.
      *
+     * <p>Creates a defensive mutable copy of the provided list to ensure
+     * the internal data can be safely modified by import strategies and
+     * other operations.</p>
+     *
      * @param data the new data
      * @param <T> the type of objects in the list
      */
     public <T> void setData(List<T> data) {
-        this.data = data;
+        // Create a defensive mutable copy to avoid UnsupportedOperationException
+        // when using immutable lists like List.of()
+        this.data = data != null ? new ArrayList<>(data) : new ArrayList<T>();
         this.modified = true;
     }
 


### PR DESCRIPTION
# Overview

Updates the `AppState.setData` method to introduce a defensive mutable copy to ensure the internal data can be safely modified without causing exceptions due to unsupported operations to mutate inmutable lists.

Closes #15

----
Special thanks to [Laimlobering](https://github.com/Laimlobering) for reporting this bug via email.